### PR TITLE
【確認待ち】ExUnit の PHP Unit テストで「ユーザーの表示名がない」と怒られたので修正

### DIFF
--- a/src/VkWpUnitTestHelpers.php
+++ b/src/VkWpUnitTestHelpers.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore
 /**
  * PHP Unit Test Helpers for WordPress
  * テストをするにあたって必要な下準備をするための処理
@@ -23,12 +23,12 @@ class VkWpUnitTestHelpers {
 
 		$test_users = array();
 
-		// テスト用ユーザーを発行
-		$userdata = array(
-			'user_login'  =>  'kurudrive',
-			'user_url'    => 'https://vektor-inc.co.jp',
-			'user_pass'   =>  'ishikawa',
-			'display_name' => 'Hidekazu Ishikawa'
+		// テスト用ユーザーを発行.
+		$userdata                = array(
+			'user_login'   => 'admin',
+			'user_url'     => 'https://vektor-inc.co.jp',
+			'user_pass'    => 'password',
+			'display_name' => 'admin',
 		);
 		$test_users['test_user'] = wp_insert_user( $userdata, $userdata['user_pass'] );
 
@@ -118,7 +118,7 @@ class VkWpUnitTestHelpers {
 			'post_title'   => 'Parent Page',
 			'post_type'    => 'page',
 			'post_status'  => 'publish',
-			'post_author'   => $test_users['test_user'],
+			'post_author'  => $test_users['test_user'],
 			'post_content' => 'content',
 		);
 		$test_posts['parent_page_id'] = wp_insert_post( $post );

--- a/src/VkWpUnitTestHelpers.php
+++ b/src/VkWpUnitTestHelpers.php
@@ -25,10 +25,10 @@ class VkWpUnitTestHelpers {
 
 		// テスト用ユーザーを発行.
 		$userdata                = array(
-			'user_login'   => 'admin',
+			'user_login'   => 'vektor',
 			'user_url'     => 'https://vektor-inc.co.jp',
 			'user_pass'    => 'password',
-			'display_name' => 'admin',
+			'display_name' => 'Vektor, Inc.',
 		);
 		$test_users['test_user'] = wp_insert_user( $userdata, $userdata['user_pass'] );
 

--- a/src/VkWpUnitTestHelpers.php
+++ b/src/VkWpUnitTestHelpers.php
@@ -15,6 +15,27 @@ namespace VK_WP_Unit_Test_Tools;
 class VkWpUnitTestHelpers {
 
 	/**
+	 * PHP Unit テストにあたって、ユーザーを登録します。
+	 *
+	 * @return array $test_users : 作成したユーザーidを配列で返します。
+	 */
+	public static function create_test_users() {
+
+		$test_users = array();
+
+		// テスト用ユーザーを発行
+		$userdata = array(
+			'user_login'  =>  'kurudrive',
+			'user_url'    => 'https://vektor-inc.co.jp',
+			'user_pass'   =>  'ishikawa',
+			'display_name' => 'Hidekazu Ishikawa'
+		);
+		$test_users['test_user'] = wp_insert_user( $userdata, $userdata['user_pass'] );
+
+		return $test_users;
+	}
+
+	/**
 	 * PHP Unit テストにあたって、各種投稿やカスタム投稿タイプ、カテゴリーを登録します。
 	 *
 	 * @return array $test_posts : 作成した投稿の記事idなどを配列で返します。
@@ -22,6 +43,7 @@ class VkWpUnitTestHelpers {
 	public static function create_test_posts() {
 
 		$test_posts = array();
+		$test_users = self::create_test_users();
 
 		/******************************************
 		 * カテゴリーの登録 */
@@ -83,6 +105,7 @@ class VkWpUnitTestHelpers {
 		$post                  = array(
 			'post_title'    => 'Test Post',
 			'post_status'   => 'publish',
+			'post_author'   => $test_users['test_user'],
 			'post_content'  => 'content',
 			'post_category' => array( $test_posts['parent_category_id'] ),
 		);
@@ -95,6 +118,7 @@ class VkWpUnitTestHelpers {
 			'post_title'   => 'Parent Page',
 			'post_type'    => 'page',
 			'post_status'  => 'publish',
+			'post_author'   => $test_users['test_user'],
 			'post_content' => 'content',
 		);
 		$test_posts['parent_page_id'] = wp_insert_post( $post );
@@ -104,6 +128,7 @@ class VkWpUnitTestHelpers {
 			'post_title'   => 'Child Page',
 			'post_type'    => 'page',
 			'post_status'  => 'publish',
+			'post_author'  => $test_users['test_user'],
 			'post_content' => 'content',
 			'post_parent'  => $test_posts['parent_page_id'],
 
@@ -115,6 +140,7 @@ class VkWpUnitTestHelpers {
 			'post_title'   => 'Post Top',
 			'post_type'    => 'page',
 			'post_status'  => 'publish',
+			'post_author'  => $test_users['test_user'],
 			'post_content' => 'content',
 		);
 		$test_posts['home_page_id'] = wp_insert_post( $post );
@@ -124,6 +150,7 @@ class VkWpUnitTestHelpers {
 			'post_title'   => 'Front Page',
 			'post_type'    => 'page',
 			'post_status'  => 'publish',
+			'post_author'  => $test_users['test_user'],
 			'post_content' => 'content',
 		);
 		$test_posts['front_page_id'] = wp_insert_post( $post );
@@ -133,6 +160,7 @@ class VkWpUnitTestHelpers {
 			'post_title'   => 'Event Test Post',
 			'post_type'    => 'event',
 			'post_status'  => 'publish',
+			'post_author'  => $test_users['test_user'],
 			'post_content' => 'content',
 		);
 		$test_posts['event_post_id'] = wp_insert_post( $post );


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

- ExUnit の PHP Unit テストで「ユーザーの表示名がない」と怒られたので修正

## どういう変更をしたか？

ExUnit の PHP Unit テストで「ユーザーの表示名がない」と怒られたのでユーザー情報を追加

## レビューに回す前に確認する事

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [ ] readme.txt に変更内容は書いたか？
=> 開発環境を更新したのみなので不要かと
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

- [x] 書けそうなテストは書いたか？


## 変更内容について何を確認したか、どういう方法で確認をしたかなど

https://github.com/vektor-inc/vk-all-in-one-expansion-unit/pull/914 と合わせて PHP Unit テストが通ることを確認しました。


## 確認URL

ローカル環境にて

## レビュワーの確認方法・確認する内容など

https://github.com/vektor-inc/vk-all-in-one-expansion-unit/pull/914 と合わせて PHP Unit テストが通ることを確認お願いします。。

## レビュワーに回す前の確認事項

- [x] このテンプレートのチェック項目をちゃんと確認してチェックしたか？

---

## レビュワー向け

### 確認して変更が反映されていない場合の確認事項

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
